### PR TITLE
explicitly setting ciphers to HIGH,MEDIUM

### DIFF
--- a/pyjojo/util.py
+++ b/pyjojo/util.py
@@ -138,7 +138,8 @@ def main():
     if options.certfile and options.keyfile:        
         server = HTTPServer(application, ssl_options={
             "certfile": options.certfile,
-            "keyfile": options.keyfile
+            "keyfile": options.keyfile,
+            "ciphers": "HIGH,MEDIUM"
         })
     else:
         log.warn("Application is running in HTTP mode, this is insecure.  Pass in the --certfile and --keyfile to use SSL.")


### PR DESCRIPTION
This should resolve #11

Doing a little testing on my machine - it didn't look like it was using the weak ciphers by default.  I was able to get it to do weak ones by adding "LOW" to the list.

test tools:
https://github.com/iSECPartners/sslyze
http://drwetter.eu/software/ssl/
