### PR TITLE
Remove setuptools dependency (so pip install works)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'pyyaml==3.10',
-    'setuptools==0.6c11',
     'tornado==3.0.1',
     'toro==0.5',
     'passlib==1.6'


### PR DESCRIPTION
We install pyjojo with pip. However, it was downgrading our setuptools from latest to 0.6c11, which breaks some other things around our system:

```
# sudo pip install pyjojo
Collecting pyjojo
/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:79: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
  Downloading pyjojo-0.9.tar.gz
Requirement already satisfied (use --upgrade to upgrade): pyyaml==3.10 in /usr/local/lib/python2.7/dist-packages/PyYAML-3.10-py2.7-linux-x86_64.egg (from pyjojo)
Collecting setuptools==0.6c11 (from pyjojo)
  Downloading setuptools-0.6c11.tar.gz (256kB)
    100% |████████████████████████████████| 258kB 755kB/s
Requirement already satisfied (use --upgrade to upgrade): tornado==3.0.1 in /usr/local/lib/python2.7/dist-packages/tornado-3.0.1-py2.7.egg (from pyjojo)
Requirement already satisfied (use --upgrade to upgrade): toro==0.5 in /usr/local/lib/python2.7/dist-packages/toro-0.5-py2.7.egg (from pyjojo)
Requirement already satisfied (use --upgrade to upgrade): passlib==1.6 in /usr/local/lib/python2.7/dist-packages/passlib-1.6-py2.7.egg (from pyjojo)
Installing collected packages: setuptools, pyjojo
  Found existing installation: setuptools 16.0
    Uninstalling setuptools-16.0:
      Successfully uninstalled setuptools-16.0
  Running setup.py install for setuptools
  Running setup.py install for pyjojo
```

This `install_require` and the pinned dependency seems unneeded (setuptools is already required to run setup.py, after all), and pyjojo itself seems to run fine without it
